### PR TITLE
Close the gap on left side of nav tabs

### DIFF
--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -4,13 +4,13 @@
   justify-content: space-around;
   border: 3px solid red;
   text-align: center;
-  width: 100%;
   flex-shrink: 0;
 }
 .container-container {
   position: absolute;
   bottom: 0;
-  width: 100%;
+  left: 0;
+  width: 100vw;
 }
 .left-tab {
   float: left;


### PR DESCRIPTION
The tabs at the bottom had a small gap between the edge of the screen and the add item tab. The CSS changes I made close the gap.
![image](https://user-images.githubusercontent.com/3941856/72690579-80670600-3ad2-11ea-8d7f-e79bac949d67.png)
